### PR TITLE
Add test fixtures for cell matching regression test

### DIFF
--- a/tests/tests/conftest.py
+++ b/tests/tests/conftest.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 
+import pooch
 import pytest
 
 
@@ -7,3 +8,23 @@ import pytest
 def data_path():
     """Directory storing all test data"""
     return Path(__file__).parent.parent / "data"
+
+
+@pytest.fixture
+def test_data_registry():
+    """
+    Create a test data registry for BrainGlobe.
+
+    Returns:
+        pooch.Pooch: The test data registry object.
+
+    """
+    registry = pooch.create(
+        path=pooch.os_cache("brainglobe_test_data"),
+        base_url="https://gin.g-node.org/BrainGlobe/test-data/raw/master/",
+        registry={
+            "cellfinder/cells-z-1000-1050.xml": None,
+            "cellfinder/other-cells-z-1000-1050.xml": None,
+        },
+    )
+    return registry

--- a/tests/tests/test_cells/test_matches.py
+++ b/tests/tests/test_cells/test_matches.py
@@ -11,12 +11,49 @@ from brainglobe_utils.cells.cells import (
     match_cells,
     match_points,
 )
+from brainglobe_utils.IO.cells import get_cells
+
+
+@pytest.fixture
+def cells_and_other_cells(test_data_registry):
+    """
+    Provides real-life cell coordinates from a CFOS-labelled brain from
+    two different cellfinder versions (pre- and post cellfinder PR #398).
+    Intended to be used for regression testing our cell matching code.
+
+    Parameters
+    ----------
+    test_data_registry : Pooch.pooch
+        The BrainGlobe test data registry.
+
+    Returns
+    -------
+    cell_data : List[Cell]
+        The loaded cell data.
+
+    """
+    cell_data_path = test_data_registry.fetch(
+        "cellfinder/cells-z-1000-1050.xml"
+    )
+    other_cell_data_path = test_data_registry.fetch(
+        "cellfinder/other_cells-z-1000-1050.xml"
+    )
+    cell_data = get_cells(cell_data_path)
+    other_cell_data = get_cells(other_cell_data_path)
+    return cell_data, other_cell_data
 
 
 def as_cell(x: List[float]):
     d = np.tile(np.asarray([x]).T, (1, 3))
     cells = from_numpy_pos(d, Cell.UNKNOWN)
     return cells
+
+
+@pytest.mark.xfail
+def test_cell_matching_regression(cells_and_other_cells):
+    cells, other_cells = cells_and_other_cells
+    # TODO implement cell matching regression test here, then remove xfail
+    assert False
 
 
 @pytest.mark.parametrize("use_scipy", [True, False])


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [x] Addition of a new feature
- [ ] Other

**Why is this PR needed?**
As discussed in https://github.com/brainglobe/brainglobe-utils/pull/74, we'd like a way to access the example cell data from the tests, without clogging the github repo.

**What does this PR do?**

* Adds a pooch registry, to make a start moving all BrainGlobe test data to GIN
* Adds a fixture to access the cell data to write a regression test for cell matching.

## References

Makes a start on https://github.com/brainglobe/BrainGlobe/issues/5

## How has this PR been tested?

I've checked locally that printing the cells after getting them via the fixture works as expected.

## Is this a breaking change?

No

## Does this PR require an update to the documentation?

Already documented [in our dev guide ](https://brainglobe.info/community/developers/intro_to_codebase.html#user-data )(but could do with an example, or a link to [our HowTo for GIN](https://howto.neuroinformatics.dev/open_science/GIN-repositories.html#download-a-gin-dataset-with-python), I guess?)

## Checklist:

- [x] The code has been tested locally (manually)
- [n/a] Tests have been added to cover all new functionality (unit & integration)
- [x] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
