### PR TITLE
Add fixtures to `pooch.fetch` more image data from GIN

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,7 @@ dev = [
     "coverage",
     "mypy",
     "pre-commit",
+    "pooch",
     "pyqt5",
     "pytest-cov",
     "pytest-qt",

--- a/tests/tests/conftest.py
+++ b/tests/tests/conftest.py
@@ -3,6 +3,8 @@ from pathlib import Path
 import pooch
 import pytest
 
+from brainglobe_utils.image_io import load_any
+
 
 @pytest.fixture
 def data_path():
@@ -25,7 +27,58 @@ def test_data_registry():
         registry={
             "cellfinder/cells-z-1000-1050.xml": None,
             "cellfinder/other-cells-z-1000-1050.xml": None,
+            "cellfinder/bright_brain.zip": None,
+            "cellfinder/edge_cells_brain.zip": None,
         },
         env="BRAINGLOBE_TEST_DATA_DIR",
     )
     return registry
+
+
+@pytest.fixture
+def bright_brain_path(test_data_registry):
+    """Fetches and unzips the contents of 'cellfinder/bright_brain.zip'
+    from GIN test data and returns the path to unzipped local folder."""
+    bright_brain_relative_path = "cellfinder/bright_brain"
+    _ = test_data_registry.fetch(
+        f"{bright_brain_relative_path}.zip",
+        processor=pooch.Unzip(extract_dir="./"),
+        progressbar=True,
+    )
+    bright_brain_absolute_path = (
+        Path(test_data_registry.path) / bright_brain_relative_path
+    )
+    assert bright_brain_absolute_path.exists()
+    return bright_brain_absolute_path
+
+
+@pytest.fixture
+def edge_cells_brain_path(test_data_registry):
+    """Fetches and unzips the contents of 'cellfinder/edge_cells_brain.zip'
+    from GIN test data and returns the path to unzipped local folder."""
+    edge_cells_brain_relative_path = "cellfinder/edge_cells_brain"
+    _ = test_data_registry.fetch(
+        f"{edge_cells_brain_relative_path}.zip",
+        processor=pooch.Unzip(extract_dir="./"),
+        progressbar=True,
+    )
+    edge_cells_brain_absolute_path = (
+        Path(test_data_registry.path) / edge_cells_brain_relative_path
+    )
+    assert edge_cells_brain_absolute_path.exists()
+    return edge_cells_brain_absolute_path
+
+
+# FIXME: putting the two tests below as proof of concept
+# and smoke tests for newly added image data on GIN.
+# Please refactor into sensible tests in other files..
+@pytest.mark.xfail
+def test_bright_brain(bright_brain_path):
+    bright_brain_signal = load_any(bright_brain_path / "signal/")
+    assert not bright_brain_signal.shape
+
+
+@pytest.mark.xfail
+def test_edge_cells_brain(edge_cells_brain_path):
+    edge_cells_brain_signal = load_any(edge_cells_brain_path / "signal/")
+    assert not edge_cells_brain_signal


### PR DESCRIPTION
Adds fixtures to fetch newly added image data from GIN, as discussed in https://github.com/brainglobe/brainglobe-utils/pull/74#issuecomment-2144383713 - hope this helps... as a sketch at least. Improvements welcome, as are general thoughts on how we should organise test data for all BrainGlobe tools ([zulip discussion](https://brainglobe.zulipchat.com/#narrow/stream/408841-development/topic/organising.20moving.20test.20data.20to.20GIN), meta-issue: https://github.com/brainglobe/BrainGlobe/issues/5)